### PR TITLE
docs(guides): Address review pass on migrating-k3s-to-rke2 guide

### DIFF
--- a/guides/migrating-k3s-to-rke2/lesson-11.md
+++ b/guides/migrating-k3s-to-rke2/lesson-11.md
@@ -396,7 +396,7 @@ $ sudo dnf install -y \
 ### Optional: Tailscale
 
 ```bash
-$ sudo dnf config-manager --add-repo https://pkgs.tailscale.com/stable/fedora//tailscale.repo
+$ sudo dnf config-manager --add-repo https://pkgs.tailscale.com/stable/centos/10/tailscale.repo
 $ sudo dnf install -y tailscale
 $ sudo systemctl enable --now tailscaled
 $ sudo tailscale up
@@ -411,7 +411,7 @@ We cover the full networking walkthrough in [Lesson 3](/guides/migrating-k3s-to-
 # Replace enp35s0 with the actual interface name
 $ sudo nmcli connection add \
     type vlan \
-    con-name vswitch0 \
+    con-name vswitch \
     dev enp35s0 \
     id 4000 \
     ipv4.method manual \
@@ -420,20 +420,20 @@ $ sudo nmcli connection add \
     ipv6.method manual \
     ipv6.addresses fd00::13/64
 
-$ sudo nmcli connection up vswitch0
+$ sudo nmcli connection up vswitch
 ```
 
-If a `vswitch0` connection already exists, use `modify` instead of `add`:
+If a `vswitch` connection already exists, use `modify` instead of `add`:
 
 ```bash
-$ sudo nmcli connection modify vswitch0 \
+$ sudo nmcli connection modify vswitch \
     ipv4.method manual \
     ipv4.addresses 10.1.0.13/16 \
     ipv4.routes "10.0.0.0/24 10.1.0.1" \
     ipv6.method manual \
     ipv6.addresses fd00::13/64
 
-$ sudo nmcli connection up vswitch0
+$ sudo nmcli connection up vswitch
 ```
 
 Configure public IPv6 on the main interface:
@@ -580,12 +580,14 @@ kubelet-arg:
   - "resolv-conf=/etc/rancher/rke2/resolv.conf"
 ```
 
-Create the clean resolv.conf for kubelet to isolate pod DNS from Tailscale's MagicDNS on the host, as described in [Lesson 6](/guides/migrating-k3s-to-rke2/lesson-6#isolating-host-dns-from-pod-dns):
+Create the clean resolv.conf for kubelet to isolate pod DNS from Tailscale's MagicDNS on the host, as described in [Lesson 5](/guides/migrating-k3s-to-rke2/lesson-5#create-configuration):
 
 ```bash
 $ cat <<'EOF' | sudo tee /etc/rancher/rke2/resolv.conf
 nameserver 1.1.1.1
 nameserver 1.0.0.1
+nameserver 2606:4700:4700::1111
+nameserver 2606:4700:4700::1001
 EOF
 ```
 
@@ -616,12 +618,13 @@ etcd-snapshot-schedule-cron: "0 */6 * * *"
 etcd-snapshot-retention: 5
 ```
 
-Each control plane node runs its own kube-apiserver, so the authentication configuration from [Lesson 9](/guides/migrating-k3s-to-rke2/lesson-9) must also be present.
-Copy `auth-config.yaml` from Node 4 and create the corresponding RKE2 config file:
+Each control plane node runs its own kube-apiserver, so the authentication configuration from [Lesson 9](/guides/migrating-k3s-to-rke2/lesson-9) and the Pod Security Admission configuration from [Lesson 5](/guides/migrating-k3s-to-rke2/lesson-5#configuring-pod-security-admission) must also be present.
+Copy both files from Node 4 and create the corresponding RKE2 config file:
 
 ```bash
-# Copy the AuthenticationConfiguration from Node 4
+# Copy the AuthenticationConfiguration and PSA config from Node 4
 $ sudo scp node4:/etc/rancher/rke2/auth-config.yaml /etc/rancher/rke2/auth-config.yaml
+$ sudo scp node4:/etc/rancher/rke2/rke2-pss.yaml /etc/rancher/rke2/rke2-pss.yaml
 ```
 
 ```yaml

--- a/guides/migrating-k3s-to-rke2/lesson-12.md
+++ b/guides/migrating-k3s-to-rke2/lesson-12.md
@@ -148,12 +148,14 @@ kubelet-arg:
   - "resolv-conf=/etc/rancher/rke2/resolv.conf"
 ```
 
-Create the clean resolv.conf as in [Lesson 6](/guides/migrating-k3s-to-rke2/lesson-6#isolating-host-dns-from-pod-dns) and [Lesson 11](/guides/migrating-k3s-to-rke2/lesson-11):
+Create the clean resolv.conf as in [Lesson 5](/guides/migrating-k3s-to-rke2/lesson-5#create-configuration) and [Lesson 11](/guides/migrating-k3s-to-rke2/lesson-11):
 
 ```bash
 $ cat <<'EOF' | sudo tee /etc/rancher/rke2/resolv.conf
 nameserver 1.1.1.1
 nameserver 1.0.0.1
+nameserver 2606:4700:4700::1111
+nameserver 2606:4700:4700::1001
 EOF
 ```
 
@@ -169,7 +171,7 @@ tls-san:
   - cluster.yourdomain.com
 ```
 
-The `00-join.yaml`, `30-security.yaml`, `40-authentication.yaml`, and `auth-config.yaml` files are identical to Node 3. See [Lesson 11](/guides/migrating-k3s-to-rke2/lesson-11) for their contents.
+The `00-join.yaml`, `30-security.yaml`, `40-authentication.yaml`, `auth-config.yaml`, and `rke2-pss.yaml` files are identical to Node 3. See [Lesson 11](/guides/migrating-k3s-to-rke2/lesson-11) for their contents.
 
 ### Starting RKE2
 

--- a/guides/migrating-k3s-to-rke2/lesson-13.md
+++ b/guides/migrating-k3s-to-rke2/lesson-13.md
@@ -62,7 +62,7 @@ $ kubectl get leases -n kube-system kube-controller-manager -o jsonpath='{.spec.
 node2_8c7a5cf9-52db-4a78-ace6-5187f4f93828%
 
 $ kubectl get leases -n kube-system kube-scheduler -o jsonpath='{.spec.holderIdentity}'
-node_ddfe2115-9b91-4bf3-a293-522659cd0edc
+node3_ddfe2115-9b91-4bf3-a293-522659cd0edc
 ```
 
 Each command prints the name of the node currently holding the lease.

--- a/guides/migrating-k3s-to-rke2/lesson-15.md
+++ b/guides/migrating-k3s-to-rke2/lesson-15.md
@@ -110,12 +110,14 @@ kubelet-arg:
 
 The `server` address points to Node 4's supervisor API on port `9345`, the same endpoint used when joining the other nodes.
 
-Create the clean resolv.conf to isolate pod DNS from Tailscale on the host, as in [Lesson 6](/guides/migrating-k3s-to-rke2/lesson-6#isolating-host-dns-from-pod-dns):
+Create the clean resolv.conf to isolate pod DNS from Tailscale on the host, as in [Lesson 5](/guides/migrating-k3s-to-rke2/lesson-5#create-configuration):
 
 ```bash
 $ cat <<'EOF' | sudo tee /etc/rancher/rke2/resolv.conf
 nameserver 1.1.1.1
 nameserver 1.0.0.1
+nameserver 2606:4700:4700::1111
+nameserver 2606:4700:4700::1001
 EOF
 ```
 
@@ -166,7 +168,7 @@ The `<none>` role for Node 1 indicates it is a pure worker.
 We can add a label for clarity:
 
 ```bash
-$ kubectl label node node1 node-role.kubernetes.io/worker=true
+$ kubectl label node node1 node-role.kubernetes.io/worker=""
 ```
 
 ### Canal and WireGuard

--- a/guides/migrating-k3s-to-rke2/lesson-2.md
+++ b/guides/migrating-k3s-to-rke2/lesson-2.md
@@ -25,18 +25,26 @@ For a comprehensive walkthrough of adding nodes to a Hetzner bare-metal cluster,
 This lesson covers the essential steps specific to our RKE2 migration.
 ' %}
 
-## Installing Rocky Linux via Hetzner Robot
+## Booting into the Hetzner Rescue System
 
-Before we can install the operating system, we need to configure the server identity in Hetzner's management interface.
-Log into the [Hetzner Robot](https://robot.hetzner.com/servers) web interface and set the server name (e.g., `node4`) along with a reverse DNS entry.
+Every node in this guide starts in the same state: booted into Hetzner's Rescue System with SSH access as root.
+The Rescue System is a minimal Linux environment that runs entirely from RAM and provides the `installimage` tool we use to deploy Rocky Linux.
+
+To activate it, log into [Hetzner Robot](https://robot.hetzner.com/servers), open the server, navigate to the **Rescue** tab, select **Linux** as the operating system, and click **Activate rescue system**.
+Robot displays a one-time root password.
+Trigger a hardware reset from Robot (or reboot the server if it is currently reachable) and the next boot will land in the rescue environment.
+
+While in Robot, also set the server name (e.g., `node4`) and a reverse DNS entry.
 A proper reverse DNS entry helps with server identification in logs and monitoring tools.
 
-After receiving the root credentials via email, access the server through SSH:
+Connect via SSH using the rescue password shown in Robot (or sent via email for a new server):
 
 ```bash
 $ ssh root@<node4-public-ip>
-# Enter password from email
+# Enter the rescue password from Robot
 ```
+
+## Installing Rocky Linux via Hetzner Robot
 
 Hetzner provides the `installimage` tool which makes OS installation straightforward on their dedicated servers.
 This tool handles disk partitioning, OS deployment, and basic configuration in one step:

--- a/guides/migrating-k3s-to-rke2/lesson-5.md
+++ b/guides/migrating-k3s-to-rke2/lesson-5.md
@@ -48,7 +48,8 @@ For a migration this is an advantage: rather than retrofitting hardening onto a 
 
 Secrets encryption at rest protects Kubernetes secrets stored in etcd, and RKE2 makes it available as a single config flag.
 Enabling it after secrets already exist requires re-encrypting every secret in etcd, so we enable it from the start before any workloads are deployed.
-Pod Security Admission follows the same principle: we enforce the `restricted` profile from the beginning rather than tightening policies later when workloads are already running and might break under stricter rules.
+Pod Security Admission gives us a single place to control which security profile pods must satisfy.
+We start permissive so system workloads (Longhorn, Traefik, and similar components that need elevated capabilities) run without exemptions, and tighten per namespace as workloads are validated.
 
 Canal, RKE2's default CNI, uses Calico's policy engine to provide L3-L4 network policies out of the box.
 We will configure Canal's network settings in [Lesson 6](/guides/migrating-k3s-to-rke2/lesson-6).
@@ -144,8 +145,13 @@ $ /etc/rancher/rke2/runc-v1.3.4 --version
 runc version 1.3.4
 commit: v1.3.4-0-g63757986
 ...
+```
 
-# Back up the original and replace with a hardlink
+Verify the SHA256 checksum of the downloaded binary against the official checksums published on the [runc releases page](https://github.com/opencontainers/runc/releases) before continuing.
+
+Back up the original and replace with a hardlink:
+
+```bash
 $ cp $RKE2_DATA_DIR/runc $RKE2_DATA_DIR/runc.v1.4.0.bak
 $ ln -f /etc/rancher/rke2/runc-v1.3.4 $RKE2_DATA_DIR/runc
 $ $RKE2_DATA_DIR/runc --version
@@ -181,16 +187,11 @@ At that point, clean up the leftover file:
 $ rm /etc/rancher/rke2/runc-v1.3.4
 ```
 
-Restart RKE2 to pick up the new binary:
-
-```bash
-$ systemctl restart rke2-server.service
-$ journalctl -u rke2-server -f
-# Wait for: "rke2 is up and running"
-```
+The patched binary will be used the next time RKE2 starts, which we configure in the [Start RKE2](#start-rke2) section below.
 
 {% include alert.liquid.html type='note' title='Apply on every node' content='
-This workaround must be applied on every node after installing RKE2 and before starting it for the first time, or before restarting it on existing nodes.
+This workaround must be applied on every node after installing RKE2 and before starting it for the first time.
+For nodes where RKE2 is already running (e.g., after re-applying the patch following an upgrade that resets the binary), restart with <code>systemctl restart rke2-server.service</code>.
 The same steps apply to Lessons 11, 12, and 15 when joining additional nodes.
 ' %}
 
@@ -279,6 +280,105 @@ disable:
 etcd-snapshot-schedule-cron: "0 */6 * * *"
 etcd-snapshot-retention: 5
 ```
+
+### Configuring Pod Security Admission
+
+RKE2 generates a default Pod Security Admission configuration at `/etc/rancher/rke2/rke2-pss.yaml` on every server start.
+Editing that file directly does not work, as RKE2 overwrites it on the next restart.
+To customize PSA we use a separate file and point RKE2 at it via the `pod-security-admission-config-file` setting, as documented in [RKE2's Pod Security Standards guide](https://docs.rke2.io/security/pod_security_standards).
+
+Create the custom config at `/etc/rancher/rke2/pss-config.yaml` with the `privileged` baseline as an explicit, visible starting point.
+This matches Kubernetes' default behavior (no restrictions) so system workloads run without exemptions, while making the configuration easy to find and tighten later:
+
+```yaml
+# /etc/rancher/rke2/pss-config.yaml
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+  - name: PodSecurity
+    configuration:
+      apiVersion: pod-security.admission.config.k8s.io/v1beta1
+      kind: PodSecurityConfiguration
+      defaults:
+        enforce: "privileged"
+        enforce-version: "latest"
+      exemptions:
+        usernames: []
+        runtimeClasses: []
+        namespaces: []
+```
+
+Tell RKE2 to use this file instead of its default by adding the setting to the security config from earlier in this lesson:
+
+```yaml
+# /etc/rancher/rke2/config.yaml.d/30-security.yaml (append)
+pod-security-admission-config-file: /etc/rancher/rke2/pss-config.yaml
+```
+
+When RKE2 starts, it regenerates the kube-apiserver static pod manifest with `--admission-control-config-file` pointing at the custom path.
+The new manifest hash causes the kubelet to recreate the apiserver pod automatically, so a `systemctl restart rke2-server` is enough.
+
+Tighten the cluster default by changing `enforce` to `baseline` or `restricted` once workloads have been audited.
+Alternatively, leave the cluster default permissive and apply tighter profiles to individual namespaces with the `pod-security.kubernetes.io/enforce` label.
+This per-namespace approach is the safer rollout path: validate one workload at a time without risking system components like Longhorn or Traefik that legitimately need elevated capabilities.
+
+#### Rollout Sequence
+
+PSA only runs at pod admission, so existing pods keep running even after enforcement tightens.
+Any restart, rescheduling, or new deployment will however be rejected if it violates the active profile, so a poorly sequenced cluster-wide change can brick the cluster the next time a control-plane static pod restarts.
+
+The safe rollout starts by labeling every existing namespace explicitly.
+Namespaces running CSI drivers, CNI plugins, or host-network workloads (`kube-system`, `longhorn-system`, and similar) get `pod-security.kubernetes.io/enforce=privileged`, and everything else gets the target profile.
+This ensures no namespace silently inherits the cluster default once that default changes.
+
+The cleanest pattern is a Namespace manifest in `/var/lib/rancher/rke2/server/manifests/` so RKE2's deploy controller applies it on every cluster start and the labels survive node rebuilds.
+`kubectl apply` semantics merge the labels into existing namespaces without conflict:
+
+```yaml
+# /var/lib/rancher/rke2/server/manifests/psa-namespace-labels.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-system
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: longhorn-system
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+# ...one entry per system namespace that needs privilege
+```
+
+For namespaces whose Namespace resource is already created by something else, set the PSA labels in that owner instead of duplicating it here.
+In this guide that means `local-path-storage` is created by the local-path-provisioner manifest in [Lesson 7](/guides/migrating-k3s-to-rke2/lesson-7), so label that manifest directly.
+The same rule applies to application namespaces owned by Pulumi modules, GitOps tooling, or Helm charts whose `createNamespace` produces an unlabeled namespace (such as `cert-manager` in [Lesson 10](/guides/migrating-k3s-to-rke2/lesson-10)), where the labels need to be applied through whatever owns the namespace.
+
+Once every namespace carries an explicit label, update `/etc/rancher/rke2/pss-config.yaml` to set `warn` and `audit` to the target profile without changing `enforce`.
+New pod creations matching disallowed patterns will then surface as warnings in `kubectl apply` output and as audit-log entries, but are still accepted:
+
+```yaml
+# /etc/rancher/rke2/pss-config.yaml
+defaults:
+  enforce: "privileged"
+  enforce-version: "latest"
+  audit: "restricted"
+  audit-version: "latest"
+  warn: "restricted"
+  warn-version: "latest"
+```
+
+As workloads are deployed to the cluster in later lessons, the `warn` and `audit` settings surface every violating pod through `kubectl apply` warnings and audit-log entries.
+These signals let us fix offenders incrementally: add `runAsNonRoot: true`, drop capabilities, set seccomp profiles, or relabel the namespace as `privileged` if the workload genuinely needs it.
+
+Once every workload in scope satisfies the target profile, the final step is to change `enforce` in `pss-config.yaml` to that profile.
+Every namespace labeled in the first step is insulated from the change, so only workloads in unlabeled namespaces are subject to the tightened default.
 
 ### Start RKE2
 
@@ -622,7 +722,6 @@ Also confirm the API server certificate includes the IPv6 SAN entries we configu
 
 ```bash
 $ openssl s_client -connect 127.0.0.1:6443 -showcerts </dev/null 2>/dev/null | \
-  openssl x509 -noout -text | grep -A1 "Subject Alternative Name"
   openssl x509 -noout -text | grep -A1 "Subject Alternative Name"
             X509v3 Subject Alternative Name:
                 DNS:kubernetes, DNS:kubernetes.default, DNS:kubernetes.default.svc, DNS:kubernetes.default.svc.cluster.local, DNS:node4, DNS:node4.k8s.local, DNS:node4.nodes.kula.app, DNS:localhost, DNS:node4, IP Address:10.1.0.14, IP Address:FD00:0:0:0:0:0:0:14, IP Address:127.0.0.1, IP Address:0:0:0:0:0:0:0:1, IP Address:10.1.0.14, IP Address:FD00:0:0:0:0:0:0:14, IP Address:10.1.0.14, IP Address:10.43.0.1

--- a/guides/migrating-k3s-to-rke2/lesson-7.md
+++ b/guides/migrating-k3s-to-rke2/lesson-7.md
@@ -82,17 +82,12 @@ Download the CLI matching the Longhorn version we install:
 ```bash
 $ curl -fL -o /usr/local/bin/longhornctl \
     https://github.com/longhorn/cli/releases/download/v1.11.0/longhornctl-linux-amd64
-
-$ curl -fL -o /tmp/longhornctl-linux-amd64.sha256 \
-    https://github.com/longhorn/cli/releases/download/v1.11.0/longhornctl-linux-amd64.sha256
-
-$ echo "$(cat /tmp/longhornctl-linux-amd64.sha256 | awk '{print $1}')  /usr/local/bin/longhornctl" | sha256sum --check
-/usr/local/bin/longhornctl: OK
-
 $ chmod +x /usr/local/bin/longhornctl
 $ /usr/local/bin/longhornctl version
 v1.11.0
 ```
+
+Verify the SHA256 checksum of the downloaded binary against the official checksums published on the [Longhorn CLI releases page](https://github.com/longhorn/cli/releases) before continuing.
 
 ### Running the Preflight Check
 

--- a/guides/migrating-k3s-to-rke2/revisions.md
+++ b/guides/migrating-k3s-to-rke2/revisions.md
@@ -1,17 +1,31 @@
 ---
 layout: guide-revisions.liquid
-title: Revision History
 
 guide_component: revisions
 guide_id: migrating-k3s-to-rke2
 repo_file_path: guides/migrating-k3s-to-rke2/revisions.md
 ---
 
+## Revision History
+
 This page tracks all changes and updates to this guide.
 
 ## Changes
 
-_none_
+- 2026-05-17 - Added "Booting into the Hetzner Rescue System" section to Lesson 2
+- 2026-05-17 - Added "Configuring Pod Security Admission" section to Lesson 5 with the `rke2-pss.yaml` file and per-namespace tightening guidance
+- 2026-05-17 - Added "Rollout Sequence" to the PSA section in Lesson 5 covering safe migration from `privileged` to a tighter cluster default
+- 2026-05-17 - Removed the incorrect first-install `systemctl restart` from the runc patching section in Lesson 5
+- 2026-05-17 - Added SHA256 checksum verification note for the runc download in Lesson 5
+- 2026-05-17 - Removed duplicated `openssl x509` line in Lesson 5 troubleshooting
+- 2026-05-17 - Replaced explicit `sha256sum --check` steps with a note for the `longhornctl` download in Lesson 7
+- 2026-05-17 - Fixed Tailscale repository URL in Lesson 11 (`stable/fedora//` → `stable/centos/10/`)
+- 2026-05-17 - Added `rke2-pss.yaml` copy step to Lesson 11 and to the identical-files list in Lesson 12 so joining control plane nodes carry the same PSA configuration as Node 4
+- 2026-05-17 - Renamed vSwitch NetworkManager connection from `vswitch0` to `vswitch` in Lesson 11 for consistency with Lesson 3
+- 2026-05-17 - Fixed broken cross-references in Lessons 11, 12, and 15 from `lesson-6#isolating-host-dns-from-pod-dns` to `lesson-5#create-configuration`
+- 2026-05-17 - Added missing secondary IPv6 nameserver `2606:4700:4700::1001` to `resolv.conf` in Lessons 11, 12, and 15 to match Lesson 5
+- 2026-05-17 - Fixed `kube-scheduler` lease holder identity typo in Lesson 13
+- 2026-05-17 - Changed worker node label value from `=true` to `=""` in Lesson 15
 
 ## Contributing
 


### PR DESCRIPTION
Apply a review pass to the published k3s-to-RKE2 migration guide.

Two new sections fill gaps in the original:

- Lesson 2 "Booting into the Hetzner Rescue System" makes the prerequisite for `installimage` explicit. The original lesson jumped straight to the installer without explaining how to reach the rescue environment, which would break a reader following it verbatim on a fresh server.
- Lesson 5 "Configuring Pod Security Admission" documents the custom-file pattern via `pod-security-admission-config-file`. Editing the RKE2-managed `/etc/rancher/rke2/rke2-pss.yaml` directly is silently reverted on every server start, which is not obvious from RKE2's docs. The section also includes a per-namespace rollout sequence for tightening enforcement without bricking system workloads (`kube-system`, `longhorn-system`, etc.) that need elevated capabilities.

Remaining changes are smaller fixes surfaced during the review:

- Wrong Tailscale repo URL for Rocky Linux (`stable/fedora//` should be `stable/centos/10/`, plus the original had a double-slash typo)
- Broken cross-references in lessons 11/12/15 to a non-existent `lesson-6#isolating-host-dns-from-pod-dns` anchor (corrected to `lesson-5#create-configuration`)
- Missing secondary IPv6 nameserver in the joining-node `resolv.conf` to match the dual-stack redundancy shown in lesson 5
- Duplicated `openssl x509` line in a troubleshooting output
- Incorrect first-install `systemctl restart` instruction in the runc patching section (the service has not been started yet at that point)
- Added the `rke2-pss.yaml` copy step to lessons 11/12 so joining control plane nodes carry the same PSA configuration as Node 4
- Replaced explicit `sha256sum --check` steps for `longhornctl` with a note pointing at the official checksums
- Renamed the vSwitch NetworkManager connection from `vswitch0` to `vswitch` in lesson 11 for consistency with lesson 3
- Fixed a typo in the `kube-scheduler` lease holder identity output in lesson 13
- Changed the worker node label value from `=true` to `=""` in lesson 15

Full list with dates in `guides/migrating-k3s-to-rke2/revisions.md`.