### PR TITLE
feat(site): Configure Sentry browser loader

### DIFF
--- a/_layouts/base.liquid.html
+++ b/_layouts/base.liquid.html
@@ -14,6 +14,21 @@
     {%- include footer.liquid.html -%}
 
     {%- if jekyll.environment == 'production' -%}
+    <script>
+      window.sentryOnLoad = function () {
+        Sentry.init({
+          environment: 'production',
+          tracesSampleRate: 0.2,
+          replaysSessionSampleRate: 0.1,
+          replaysOnErrorSampleRate: 1.0,
+        });
+      };
+    </script>
+    <script
+      data-lazy='no'
+      src='https://js.sentry-cdn.com/c5110cd45f171ad570cc55c85905f775.min.js'
+      crossorigin='anonymous'
+    ></script>
     <script
       defer
       src='https://analytics.lab.philprime.dev/umami'

--- a/privacy.md
+++ b/privacy.md
@@ -2,8 +2,8 @@
 layout: page.liquid
 title: Privacy Policy
 permalink: /privacy/
-description: "Privacy policy for philprime.dev, including information about analytics and data collection."
-keywords: "privacy policy, data protection, analytics, umami"
+description: "Privacy policy for philprime.dev, including information about analytics, error monitoring, and data collection."
+keywords: "privacy policy, data protection, analytics, umami, sentry"
 image: /assets/images/default-og-image.png
 ---
 
@@ -25,15 +25,29 @@ The following information is collected:
 - Device type (desktop, mobile, tablet)
 - Visitor country (derived from IP address, which is not stored)
 
-No personal information is collected, stored, or shared with third parties.
+## Error and Performance Monitoring
+
+Production pages use [Sentry](https://sentry.io) to detect JavaScript errors, monitor performance, and understand what happened before or during a problem.
+Sentry is configured for error monitoring, performance tracing, and sampled session replay.
+
+Depending on whether an error, trace, or sampled replay is captured, Sentry may receive technical data such as:
+
+- Page URL, referrer, timestamp, browser, operating system, and device information
+- Error messages, stack traces, source file names, line numbers, and console breadcrumbs
+- Performance timing information for sampled page loads, navigation, and browser requests
+- Masked replay data for sampled sessions, such as DOM structure, clicks, scrolling, network request metadata, and console entries
 
 ## Cookies
 
-This site does not use cookies.
+This site does not use cookies for analytics or monitoring.
+Sentry Session Replay may use browser session storage to keep replay state for the current browser tab.
 
 ## Third-Party Services
 
-Content may occasionally embed or link to third-party services (e.g. GitHub, YouTube).
+This site loads scripts and styles from service providers used to operate the site, including Sentry, Umami, and CDN providers for frontend assets.
+Those providers may receive standard request metadata such as IP address, requested URL, referrer, user agent, and timestamp when your browser requests their resources.
+
+Content may occasionally embed or link to third-party services (for example GitHub or YouTube).
 These services have their own privacy policies, and interacting with embedded content may be subject to their terms.
 
 ## Contact
@@ -43,4 +57,4 @@ If you have questions about this policy, you can reach me at [legal@philprime.de
 ## Changes
 
 This policy may be updated from time to time.
-Last updated: March 2026.
+Last updated: May 2026.


### PR DESCRIPTION
Configure the Sentry browser loader for production Jekyll pages.

The static site already included the generated loader script, but it loaded after analytics scripts and did not provide an initialization callback. This adds the loader configuration before the loader tag so browser error monitoring, tracing, and session replay sampling are enabled consistently across generated pages.

The loader is made eager so tracing and replay are available before later deferred analytics scripts run.